### PR TITLE
New styles for artwork preview in search results

### DIFF
--- a/sass/main.scss
+++ b/sass/main.scss
@@ -262,14 +262,13 @@ header{
 
     .preview-subhead h5{
         font-family: $MiaGroteskBold;
-        margin-bottom:20px;
         color:$support;
+        cursor:hand;
     }
     
      .preview-subhead h6{
          color:$support;
-         float:right;
-         display:inline-block;
+         cursor:hand;
      }
 
 


### PR DESCRIPTION
Consolidated and cleaned up header for 'objects-focus'
Moved Gallery into the header
centered images in the pane
Fixed line-heights in header to match brand guides
Added a grey background for some orientation
Removed unnecessary black bar
Added link color to the clickable stuff