### PR TITLE
Darken top quilt

### DIFF
--- a/sass/main.scss
+++ b/sass/main.scss
@@ -292,6 +292,9 @@ header{
     }
 
 
+.search-wrap {
+  z-index: 1000;
+}
 .search-wrap div:first-child {
     width: 23em;
     margin:0 auto;

--- a/src/image-quilt.js
+++ b/src/image-quilt.js
@@ -96,8 +96,14 @@ const ImageQuilt = React.createClass({
       </div>
     })
 
+    var quiltStyle = {
+      cursor: 'pointer',
+      WebkitFilter: this.props.darken ? 'brightness(0.3)' : '',
+      ...this.props.style,
+    }
+
     return (
-      <div className='quilt-wrap'  onMouseLeave={this.hovered.bind(this, null, false)} style={{cursor: 'pointer'}}>
+      <div className='quilt-wrap' onMouseLeave={this.hovered.bind(this, null, false)} style={quiltStyle}>
         {images}
       </div>
     )
@@ -205,7 +211,8 @@ var QuiltPatch = React.createClass({
 
   getDefaultProps() {
     return {
-      lazyLoad: true
+      lazyLoad: true,
+      darken: false,
     }
   },
 })

--- a/src/image-quilt.js
+++ b/src/image-quilt.js
@@ -2,6 +2,7 @@ var React = require('react')
 var {Link} = require('react-router')
 var PureRenderMixin = require('react/addons').addons.PureRenderMixin
 var debounce = require('debounce')
+var cookie = require('react-cookie')
 
 var linearPartition = require('linear-partitioning')
 var ArtworkImage = require('./artwork-image')
@@ -15,6 +16,7 @@ const ImageQuilt = React.createClass({
       active: null,
       unpinned: false,
       width: window.innerWidth || this.context.universal && 1000,
+      alwaysShow: cookie.load('freeTheQuilt')
     }
   },
 
@@ -31,6 +33,8 @@ const ImageQuilt = React.createClass({
   },
 
   render() {
+    if(this.hideDarkenedQuilt()) return this.emptyQuiltToggleControl()
+
     const artworks = this.props.artworks.slice(0, this.props.maxWorks)
     const _art = artworks.map((art) => {
       var s = art._source
@@ -83,7 +87,7 @@ const ImageQuilt = React.createClass({
       const justify = index == 0 && row.length <=3 ? 'space-around' : 'center'
       var rowStyle = {
         background: '#222',
-        minHeight: Math.min(unadjustedHeight, this.props.maxRowHeight),
+        minHeight: Math.min(unadjustedHeight, this.props.maxRowHeight || 200, 50),
         display: 'flex',
         justifyContent: justify,
         whiteSpace: 'nowrap',
@@ -98,7 +102,6 @@ const ImageQuilt = React.createClass({
 
     var quiltStyle = {
       cursor: 'pointer',
-      WebkitFilter: this.props.darken ? 'brightness(0.3)' : '',
       ...this.props.style,
     }
 
@@ -158,6 +161,29 @@ const ImageQuilt = React.createClass({
       return
     }
     this.activate = setTimeout(this.clicked.bind(this, art, false), 300)
+  },
+
+  hideDarkenedQuilt() {
+    return this.props.darken && !this.state.alwaysShow
+  },
+
+  emptyQuiltToggleControl() {
+    var styles = {
+      minHeight: '7rem',
+      display: 'inline-block',
+      width: '100%',
+      WebkitUserSelect: 'none',
+      cursor: 'pointer',
+      backgroundColor: 'red',
+      zIndex: 100,
+    }
+
+    return <span style={styles} onClick={this.freeTheQuilt} />
+  },
+
+  freeTheQuilt() {
+    cookie.save('freeTheQuilt', true)
+    this.setState({alwaysShow: true})
   },
 })
 ImageQuilt.contextTypes = {

--- a/src/search.js
+++ b/src/search.js
@@ -36,7 +36,7 @@ var Search = React.createClass({
       onClick: this.updateFromQuilt,
       disableHover: this.props.hideResults,
       lazyLoad: !this.context.universal,
-      darken: true,
+      darken: this.props.path && this.props.path.match(/search/),
     }, this.props.quiltProps || {})
 
     const nakedSimpleSearchBox = <div className='mdl-textfield mdl-js-textfield'>

--- a/src/search.js
+++ b/src/search.js
@@ -36,6 +36,7 @@ var Search = React.createClass({
       onClick: this.updateFromQuilt,
       disableHover: this.props.hideResults,
       lazyLoad: !this.context.universal,
+      darken: true,
     }, this.props.quiltProps || {})
 
     const nakedSimpleSearchBox = <div className='mdl-textfield mdl-js-textfield'>


### PR DESCRIPTION
Should all the 'decorative' quilts be darkened? Including the homepage

> [![image](https://cloud.githubusercontent.com/assets/1378/9857828/98f24f7e-5ae2-11e5-9f08-a7aa846614c2.png)](http://collection.staging.artsmia.org)

and department pages?

> [![image](https://cloud.githubusercontent.com/assets/1378/9857836/a423f794-5ae2-11e5-89cd-d9c2eb652def.png)](http://collection.staging.artsmia.org/departments/Paintings)

Or only darken the top quilt on search result pages where the same images get stacked on top and in the left column

> [![image](https://cloud.githubusercontent.com/assets/1378/9857869/dd261054-5ae2-11e5-8c9a-d765ad00fd71.png)](http://collection.staging.artsmia.org/search/arch)