### PR TITLE
Language

### DIFF
--- a/src/search-language.js
+++ b/src/search-language.js
@@ -14,6 +14,7 @@ var searchLanguageMap = (queryText) => {
     'room:"Not on View"': 'Not on View',
     'image:valid': "Image Available",
     'image:invalid': "Image Unavailable",
+    'room:"G320"': "TODO: need to match parameters more cleverly? This should return 'In Gallery 320' or something",
   }
 
 


### PR DESCRIPTION
Make inscrutable elasticsearch query string language easier to understand.
- [x] replace ES query strings (`highlight:true`, `recent:true`, `image:valid`) with smoother, more understandable english ("Museum Highlights", "Recent Accessions", "Image Available")
- [ ] find a new name for "Gist"

@mtongen what else?
