### PR TITLE
Exhibitions

### DIFF
--- a/routes.js
+++ b/routes.js
@@ -17,6 +17,7 @@ var Page = require('./src/page')
 var Info = require('./src/info')
 var Gallery = require('./src/gallery')
 var Map = require('./src/map-page')
+var Exhibition = require('./src/exhibition')
 
 var routes = (
   <Route handler={App} path="/">
@@ -39,6 +40,8 @@ var routes = (
     <Route name="gallery" path="/galleries/:gallery" handler={Gallery} />
     <Route name="map" path="/map" handler={Map} />
     <Route name="galleries" path="/galleries" handler={Map} />
+    <Route name="exhibition" path="/exhibitions/:id" handler={Exhibition} />
+    <Route name="exhibitionSlug" path="exhibitions/:id/:slug" handler={Exhibition} />
   </Route>
 );
 

--- a/sass/main.scss
+++ b/sass/main.scss
@@ -978,7 +978,21 @@ button.material-icons {
   padding: 0px;
   font-weight: bold;
 }
-
+.exhibition p {
+  padding: 0 0 10px 0;
+}
+.exhibition p > span.exh_title{
+  font-family: $MiaGroteskBold;
+  line-height: 1.1em;
+}
+.exhibition h4 {
+  color: #999999;
+  text-transform: uppercase;
+  line-height: 1em;
+  padding: 10px 0 0 0;
+  margin: 0;
+  font-family: $MiaGroteskLight;
+}
 /* ===== page.js STYLES ===== */
 
 .page{}

--- a/sass/main.scss
+++ b/sass/main.scss
@@ -861,13 +861,17 @@ h5.details-title {
 .explore{
   display: inline-block;
 }
-.explore a {
-  font-size:1.1em;
-  color: #ffffff;
-  font-family: $MiaGroteskBold, sans-serif;
-  position: absolute;
-  bottom:10px;
-  left: 10px;
+.explore {
+  .newsflash, .artstory, .explore-content {
+    a {
+      font-size:1.1em;
+      color: #ffffff;
+      font-family: $MiaGroteskBold, sans-serif;
+      position: absolute;
+      bottom:10px;
+      left: 10px;
+    }
+  }
 }
 .explore .adopt-ptg {
   margin-top: 10px;

--- a/server.js
+++ b/server.js
@@ -35,7 +35,7 @@ app.use((req, res, next) => {
     location: req.url,
     onAbort: ({to, params, query}) => {
       var url = to && router.makePath(to, params, query) || '/'
-      res.redirect(302, url)
+      res.redirect(301, url)
     },
   })
 

--- a/src/artwork-related.js
+++ b/src/artwork-related.js
@@ -25,6 +25,9 @@ var ArtworkRelatedContent = React.createClass({
     var meat = <div className="explore">
       {links.map(this.build)}
     </div>
+    var exhibitions = <div className="exhibition_item">
+      {links.map(this.exhibition)}
+    </div>
 
     var bones = this.props.skipWrapper ?
       meat :
@@ -33,13 +36,35 @@ var ArtworkRelatedContent = React.createClass({
         {meat}
       </div>
 
-    return links && links.length > 0 && bones
+      var exhib_bones = this.props.skipWrapper ?
+        exhibitions :
+        <div className="exhibitionWrapper">
+          <h5 className="details-title">Exhibitions</h5>
+          {exhibitions}
+        </div>
+
+    return <div>
+    {links && links.length > 0 && bones} {links && links.length > 0 && exhib_bones}
+          </div>
   },
 
   build(link) {
-    return <div key={link.link}>
-      {(this.templates[link.type] || this.templates.default)(link, this.props.id, this.props.highlights)}
-    </div>
+    if (!(link.type === "exhibition")){
+      return <div key={link.link}>
+        {(this.templates[link.type] || this.templates.default)(link, this.props.id, this.props.highlights)}
+      </div>
+    } else {
+
+    }
+  },
+  exhibition(link) {
+    if (link.type === "exhibition"){
+      return <div key={link.link}>
+        {(this.templates[link.type] || this.templates.default)(link, this.props.id, this.props.highlights)}
+      </div>
+    } else {
+
+    }
   },
 
   templates: {
@@ -85,11 +110,7 @@ var ArtworkRelatedContent = React.createClass({
       var otherArtCount = json.objectIds ? json.objectIds.length-1 : '(x)'
 
       return <div className="exhibition" style={{clear: "both"}}>
-        <span>This was shown in the exhibition</span> &nbsp;
-        <h4 style={{display: 'inline'}}>
-          <Link to="exhibition" params={{id: json.id}}>{json.title}</Link>
-        </h4> &nbsp;
-        <span>with {otherArtCount} other objects. {json.description}</span>
+        <p>This was shown in the exhibition <span className="exh_title"><Link to="exhibition" params={{id: json.id}}>{json.title}</Link></span> with {otherArtCount} other objects. {json.description}</p>
       </div>
     },
     default: (link) => <div className="explore-content" style={{backgroundColor: "rgb(35,35,35)"}}>

--- a/src/artwork-related.js
+++ b/src/artwork-related.js
@@ -21,11 +21,13 @@ var ArtworkRelatedContent = React.createClass({
 
   render() {
     var {links} = this.props
+    var exhibitions = links.filter(link => link.type == "exhibition")
+    var explore = links.filter(link => link.type !== "exhibition")
 
     var meat = <div className="explore">
       {links.map(this.build)}
     </div>
-    var exhibitions = <div className="exhibition_item">
+    var exhibition_wrap = <div className="exhibition_item">
       {links.map(this.exhibition)}
     </div>
 
@@ -40,11 +42,11 @@ var ArtworkRelatedContent = React.createClass({
         exhibitions :
         <div className="exhibitionWrapper">
           <h5 className="details-title">Exhibitions</h5>
-          {exhibitions}
+          {exhibition_wrap}
         </div>
 
     return <div>
-    {links && links.length > 0 && bones} {links && links.length > 0 && exhib_bones}
+    {explore && explore.length > 0 && bones} {exhibitions && exhibitions.length > 0 && exhib_bones}
           </div>
   },
 

--- a/src/artwork-related.js
+++ b/src/artwork-related.js
@@ -21,14 +21,16 @@ var ArtworkRelatedContent = React.createClass({
 
   render() {
     var {links} = this.props
-    var exhibitions = links.filter(link => link.type == "exhibition")
     var explore = links.filter(link => link.type !== "exhibition")
+    var exhibitions = links.filter(link => link.type == "exhibition")
+    // only show exhibitions with more than a single object
+    var significantExhibitions = exhibitions.filter(ex => ex.objectIds.length > 1)
 
     var meat = <div className="explore">
       {explore.map(this.build)}
     </div>
     var exhibition_wrap = <div className="exhibition_item">
-      {exhibitions.map(this.build)}
+      {significantExhibitions.map(this.build)}
     </div>
 
     var bones = this.props.skipWrapper ?

--- a/src/artwork-related.js
+++ b/src/artwork-related.js
@@ -25,10 +25,10 @@ var ArtworkRelatedContent = React.createClass({
     var explore = links.filter(link => link.type !== "exhibition")
 
     var meat = <div className="explore">
-      {links.map(this.build)}
+      {explore.map(this.build)}
     </div>
     var exhibition_wrap = <div className="exhibition_item">
-      {links.map(this.exhibition)}
+      {exhibitions.map(this.build)}
     </div>
 
     var bones = this.props.skipWrapper ?
@@ -46,27 +46,15 @@ var ArtworkRelatedContent = React.createClass({
         </div>
 
     return <div>
-    {explore && explore.length > 0 && bones} {exhibitions && exhibitions.length > 0 && exhib_bones}
-          </div>
+      {explore && explore.length > 0 && bones}
+      {exhibitions && exhibitions.length > 0 && exhib_bones}
+    </div>
   },
 
   build(link) {
-    if (!(link.type === "exhibition")){
-      return <div key={link.link}>
-        {(this.templates[link.type] || this.templates.default)(link, this.props.id, this.props.highlights)}
-      </div>
-    } else {
-
-    }
-  },
-  exhibition(link) {
-    if (link.type === "exhibition"){
-      return <div key={link.link}>
-        {(this.templates[link.type] || this.templates.default)(link, this.props.id, this.props.highlights)}
-      </div>
-    } else {
-
-    }
+    return <div key={link.link}>
+      {(this.templates[link.type] || this.templates.default)(link, this.props.id, this.props.highlights)}
+    </div>
   },
 
   templates: {

--- a/src/artwork-related.js
+++ b/src/artwork-related.js
@@ -1,5 +1,6 @@
 var React = require('react')
 var rest = require('rest')
+var {Link} = require('react-router')
 
 var Markdown = require('./markdown')
 var imageCDN = require('./image-cdn')
@@ -12,7 +13,7 @@ var artstoryStampStyle = {
 var ArtworkRelatedContent = React.createClass({
   statics: {
     fetchData: (params) => {
-      return rest('http://collection.staging.artsmia.org/links/'+params.id+'.json')
+      return rest('http://collections.artsmia.org/links/'+params.id+'.json')
       .then(r => JSON.parse(r.entity))
       .catch(err => [])
     },
@@ -79,6 +80,17 @@ var ArtworkRelatedContent = React.createClass({
           </div>
         </div>
       }
+    },
+    "exhibition": (json, id, highlights) => {
+      var otherArtCount = json.objectIds ? json.objectIds.length-1 : '(x)'
+
+      return <div className="exhibition" style={{clear: "both"}}>
+        <span>This was shown in the exhibition</span> &nbsp;
+        <h4 style={{display: 'inline'}}>
+          <Link to="exhibition" params={{id: json.id}}>{json.title}</Link>
+        </h4> &nbsp;
+        <span>with {otherArtCount} other objects. {json.description}</span>
+      </div>
     },
     default: (link) => <div className="explore-content" style={{backgroundColor: "rgb(35,35,35)"}}>
       <div className="overlay">

--- a/src/endpoints.js
+++ b/src/endpoints.js
@@ -2,4 +2,5 @@ module.exports = {
   search: "http://search.artsmia.org",
   info: "http://artsmia.github.io/collection-info/index.json",
   dimensionSvg: (id, file) => `http://collections.artsmia.org/dimensions/${id}/${file || 'dimensions'}.svg`,
+  exhibition: (id) => `http://cdn.dx.artsmia.org/exhibitions/${Math.floor(id/1000)}/${id}.json`,
 }

--- a/src/exhibition.js
+++ b/src/exhibition.js
@@ -1,0 +1,68 @@
+var React = require('react')
+var Router = require('react-router')
+var rest = require('rest')
+var Helmet = require('react-helmet')
+
+var Search = require('./search')
+var endpoints = require('./endpoints')
+var SEARCH = endpoints.search
+var toSlug = require('speakingurl')
+
+var Exhibition = React.createClass({
+  mixins: [Router.State],
+  statics: {
+    fetchData: {
+      exhibition: (params) => {
+        var {id} = params
+        return rest(endpoints.exhibition(id))
+        .then((r) => JSON.parse(r.entity))
+        .then(exh => {
+          exh.slug = toSlug(exh.exhibition_title)
+          return exh
+        })
+      },
+
+      searchResults: (params, query) => {
+        return Exhibition.fetchData.exhibition(params).then(exhibition => {
+          var searchUrl = `${SEARCH}/ids/${exhibition.objects.join(',')}`
+          return rest(searchUrl).then((r) => JSON.parse(r.entity))
+        })
+      },
+    },
+
+    willTransitionTo: function (transition, params, query, callback) {
+      Exhibition.fetchData.exhibition(params).then(exhibition => {
+        if(exhibition.slug !== params.slug) {
+          params.slug = exhibition.slug
+          transition.redirect('exhibitionSlug', params)
+        }
+      }).then(callback)
+    },
+  },
+
+  render() {
+    var {exhibition} = this.props.data
+
+    return <div>
+      <Search
+        {...this.props}
+        disableHover={true} // TODO: fix :hover going to the search results page
+      >
+        <div style={{textAlign: 'center'}}>
+          <h2>{exhibition.exhibition_title}</h2>
+          <p>{exhibition.display_date}</p>
+        </div>
+        <hr />
+      </Search>
+      <Helmet
+        title={`Exhibition: ${exhibition.exhibition_title}`}
+        meta={[
+          {property: "og:title", content: exhibition.exhibition_title + ' ^ Minneapolis Institute of Art'},
+          {property: "og:description", content: `An exhibition at the Minneapolis Institute of Art. ${exhibition.display_date}`},
+        ]}
+      />
+    </div>
+  },
+})
+
+module.exports = Exhibition


### PR DESCRIPTION
Very basic browse exhibition functionality. Right now the only way to get to an exhibition page is through an object that was in an exhibition.

[Search for all objects with related exhibitions](http://collections.staging.artsmia.org/search/_exists_:%22related:exhibitions%22)

A few random exhibitions

[Marks of Genius](http://collections.staging.artsmia.org/exhibitions/1610/marks-of-genius-100-extraordinary-drawings-from-the-minneapolis-institute-of-arts)
["Gifts for the new Millenium"](http://collections.staging.artsmia.org/exhibitions/403/a-world-of-art-gifts-for-the-new-millennium)
# Things to look at:
- **Exhibition pages show loan objects**. Which in the context of an exhibition, I think makes sense? It would be cool if we could leave them there with a note that some art gets loaned to the museum especially for _exhibition a_ and then leaves, sorry, it doesn't belong to Mia.
- [ ] can we show loaned objects in the context of an exhibition?
- **External exhibitions are included as well**. [Lucretia](http://collections.staging.artsmia.org/art/529/lucretia-rembrandt-harmensz-van-rijn) has an exhibition listing for "Rembrandt: The late works", which went to the [Rijksmuseum](https://www.rijksmuseum.nl/en/late-rembrandt) and [National Gallery](http://www.nationalgallery.org.uk/whats-on/exhibitions/rembrandt-the-late-works), but didn't quite make it to Minneapolis
- [ ] how do we know if an exhibition existed at Mia, or one of our objects was loaned? Sometimes it's both.

(I'll update this as I think of more things)
