### PR TITLE
detect `smallViewport` in App, pass by context

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "serve-static": "^1.10.0",
     "speakingurl": "^6.0.0",
     "split-array": "1.0.1",
+    "useragent": "2.1.9",
     "when": "^3.6.4"
   }
 }

--- a/src/app.js
+++ b/src/app.js
@@ -33,8 +33,13 @@ var App = React.createClass({
   },
 
   getChildContext() {
+    const isSmallViewportDevice =
+      this.props.ua && !!this.props.ua.match('palm') ||
+      window && window.innerWidth && window.innerWidth <= 500
+
     return {
       universal: this.props.universal,
+      smallViewport: isSmallViewportDevice,
     }
   },
 
@@ -96,6 +101,9 @@ var App = React.createClass({
       <a href="#" title="Show menu" onClick={this.toggleMenu}>{logo}</a>
   },
 })
-App.childContextTypes = {universal: React.PropTypes.bool}
+App.childContextTypes = {
+  universal: React.PropTypes.bool,
+  smallViewport: React.PropTypes.bool,
+}
 
 module.exports = App

--- a/src/artwork.js
+++ b/src/artwork.js
@@ -50,7 +50,7 @@ var Artwork = React.createClass({
     var id = this.props.id || this.state.id
     const highlights = this.props.highlights
     var stickyMapStyle = this.context.universal ? {position: 'fixed'} : {}
-    var smallViewport = window && window.innerWidth <= 500
+    var {smallViewport} = this.context
 
     var pageTitle = [
       art.title.replace(/<[^ ]+?>/g, '"'),
@@ -148,7 +148,7 @@ var Artwork = React.createClass({
   componentDidMount() {
     var art = this.state.art
     if(art.image === 'valid' && art.restricted != 1 && !this.isLoan()) this.loadZoom()
-    var smallViewport = window && window.innerWidth <= 500
+    var {smallViewport} = this.context
     // push the viewport down past the header to maximize image/text on the page
     // scrolling back up reveals the menu
     // TODO: is there a way to automatically trigger safari's minimal chrome other than a user-initiated scroll event? (probably not https://stackoverflow.com/a/26884561)
@@ -205,7 +205,7 @@ var Artwork = React.createClass({
         zoomCount += 1
         nowZoom > prevZoom ? zoomInCount += 1 : zoomOutCount += 1
 
-        var smallViewport = window && window.innerWidth <= 500
+        var {smallViewport} = this.context
         var isSecondZoomInAction = zoomInCount == 2
         if(smallViewport && !recentlyAutoZoomed) {
           // fullscreen the image when a user zooms twice in a row
@@ -243,7 +243,7 @@ var Artwork = React.createClass({
       —Nope! We're loading ${humanizeNumber(this.getPixelDifference(400))} more pixels right now.
       It can take a few seconds.)`
     var showLoadingMessage = zoomLoading && zoomLoaded === false && !this.context.universal
-    var smallViewport = window && window.innerWidth <= 500
+    var {smallViewport} = this.context
 
     return art.image === 'valid' && <span className="imageStatus">
       {showLoadingMessage && loadingZoomMessage}
@@ -274,6 +274,7 @@ var Artwork = React.createClass({
 Artwork.contextTypes = {
   router: React.PropTypes.func,
   universal: React.PropTypes.bool,
+  smallViewport: React.PropTypes.bool,
 }
 
 module.exports = Artwork

--- a/src/home.js
+++ b/src/home.js
@@ -22,7 +22,7 @@ var Home = React.createClass({
   },
 
   render() {
-    let smallViewport = window && window.innerWidth < 600
+    let {smallViewport} = this.context
     let quiltProps = smallViewport ?
       {maxRows: 2, maxWorks: 7} :
       {maxRows: 3, maxWorks: 30}
@@ -49,6 +49,9 @@ var Home = React.createClass({
     </div>
   },
 })
+Home.contextTypes = {
+  smallViewport: React.PropTypes.bool,
+}
 
 module.exports = Home
 

--- a/src/more.js
+++ b/src/more.js
@@ -23,7 +23,7 @@ var More = React.createClass({
   },
 
   render() {
-    let smallViewport = window && window.innerWidth < 600
+    let {smallViewport} = this.context
     let quiltProps = {maxRows: 2, maxWorks: 7}
 
     return <div>

--- a/src/navigation.js
+++ b/src/navigation.js
@@ -22,6 +22,7 @@ var GlobalNavigation =  React.createClass({
   render() {
 
     var smallViewport = window && window.innerWidth <= 780
+    // … why 780 here instead of 600 elsewhere?
 
 
       if(smallViewport){

--- a/src/search-results.js
+++ b/src/search-results.js
@@ -27,8 +27,8 @@ var SearchResults = React.createClass({
   getInitialState() {
     var focus = window.clickedArtwork || this.props.hits[0]
     setTimeout(() => window.clickedArtwork = null)
-    var smallViewport = window && window.innerWidth <= 500
-    var defaultView = (smallViewport || this.context.universal) ? ResultsList : ResultsGrid
+    var {smallViewport, universal} = this.context
+    var defaultView = (smallViewport || universal) ? ResultsList : ResultsGrid
 
     return {
       focusedResult: focus && focus,

--- a/src/search-summary.js
+++ b/src/search-summary.js
@@ -19,7 +19,7 @@ const SearchSummary = React.createClass({
 
     const showingAll = hits.length == search.hits.total || hits.length >= this.props.maxResults
 
-    var smallViewport = window && window.innerWidth <= 500
+    var {smallViewport} = this.context
     var toolbarClasses = "summaryText mdl-cell " + (smallViewport ?
       "mdl-cell--4-col" :
       "mdl-cell--8-col mdl-cell--4-col-tablet")


### PR DESCRIPTION
This will let the site skip the flash from server-rendered side-by-side layout to the client rendered "palm only" top/bottom.
- [ ] test on devices
- [ ] update on `orientationchange` and `window.resize`
