### PR TITLE
Save image details

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ var ReactDOM = require('react-dom')
 var Router = require('react-router')
 var fetchComponentData = require('./fetch')
 var fathom = require('fathom-client')
+var {isInternetArchivedPage} = require('./src/util/archived-page-handler.js')
 
 var routes = require('./routes')
 
@@ -13,6 +14,19 @@ if(trackAnalytics) Fathom.load('PXCWTLRI', {
 })
 
 window.history && history.replaceState({}, '', window.location.href.replace(/\/(.*)\/$/, '/$1'))
+
+// Patch react-router to render the correct pages even when they're archived
+// with a different URL at the internet archive
+Router.HistoryLocation.__unpatched__getCurrentPath = Router.HistoryLocation.getCurrentPath
+Router.HistoryLocation.getCurrentPath = function getCurrentPath() {
+  // re-write `pathname` to render even when this page is archived at the internet
+  // archive…
+  var iaPathRegex = new RegExp("/web/[0-9]+/http://collections.artsmia.org")
+  var pathnameWithoutWaybackPrefix = window.location.pathname
+    .replace(iaPathRegex, '')
+
+  return decodeURI(pathnameWithoutWaybackPrefix + window.location.search);
+}
 
 Router.run(routes, Router.HistoryLocation, (Handler, state) => {
   if(trackAnalytics) Fathom.trackPageview()

--- a/src/_artwork.js
+++ b/src/_artwork.js
@@ -179,6 +179,8 @@ var CopyableLabel = React.createClass({
 
 // check if an image exists on our cloudfront distribution,
 // and if not, fall back to loading it from the API
+// TODO - this actually loads the full image, which is unneccessary and slows down the page.
+// Somehow just do a HEAD request?
 var testCloudfrontImage = (art, callback) => {
   var rights = rightsDescriptions.getRights(art)
   var downloadFullRes = art.rights_type === 'Public Domain'

--- a/src/artwork-details.js
+++ b/src/artwork-details.js
@@ -187,7 +187,7 @@ var ArtworkDetails = React.createClass({
         </div>]
       }],
       ['IIIF', (art) => {
-        if(art.rights_type !== 'Public Domain') return []
+        if(true || art.rights_type !== 'Public Domain') return []
 
         const manifestLink = `https://iiif.dx.artsmia.org/${art.id}.jpg/manifest.json`
         const uvLink = `https://universalviewer.io/uv.html?manifest=${manifestLink}`

--- a/src/artwork.js
+++ b/src/artwork.js
@@ -163,10 +163,9 @@ var Artwork = React.createClass({
       </div>}
       {false && <ClosedBanner />}
 
-      {false && <a href={`default_target?image=https://iiif.dx.artsmia.org/${this.state.id}.jpg/info.json`}>
+      {false && <a href={`?manifest=https://iiif.dx.artsmia.org/${this.state.id}.jpg/manifest.json`}>
         <img src="iiif-dragndrop-100px.png" alt="IIIF Drag-n-drop" /> IIIF!
       </a>}
-
     </div>
 
     var smallViewportWithTabbedInfoAndRelated = <div>

--- a/src/artwork/page-metadata.js
+++ b/src/artwork/page-metadata.js
@@ -37,7 +37,11 @@ module.exports = ({art, noIndex, prependTitle}) => {
           content: noIndex ? 'noindex, nofollow' : 'all',
         },
       ]}
-      link={[{ rel: 'canonical', href: canonicalURL }]}
+      link={[
+        { rel: 'canonical', href: canonicalURL },
+        { rel: 'prefetch', href: `https://search.artsmia.org/id/${art.id}` },
+        { rel: 'prefetch', href: `https://iiif.dx.artsmia.org/${art.id}.jpg/info.json` },
+      ]}
     />
   )
 }

--- a/src/pages/not-found.js
+++ b/src/pages/not-found.js
@@ -1,4 +1,5 @@
 var React = require('react')
+var {isInternetArchivedPage} = require('../util/archived-page-handler.js')
 
 var coverPageStyle = {
   textAlign: 'center',
@@ -17,10 +18,11 @@ var NotFound = React.createClass({
     willTransitionTo: function (transition, params, query, callback) {
       var redirectUrl = params && isInternetArchivedPage(params.splat)
 
-      if(redirectUrl) {
-        console.info('re-route for IA archived page', {
-          redirectUrl,
-        })
+      if(false && redirectUrl) {
+        // `transition` happens at the server level and results
+        // in a 301 redirect, which doesn't fix the problem with this site
+        // archived on archive.org
+        // Time for a better idea!
         transition.redirect(redirectUrl)
       }
 
@@ -29,12 +31,5 @@ var NotFound = React.createClass({
   }
 })
 
-function isInternetArchivedPage(url) {
-  var internetArchiveUrlRegex = new RegExp("/?web/[0-9]+/http://collections.artsmia.org(.*)")
-  var isInternetArchivedPage = url && url.match(internetArchiveUrlRegex)
-  var pageUrl = isInternetArchivedPage && isInternetArchivedPage[1]
-
-  return pageUrl
-}
 
 module.exports = NotFound

--- a/src/util/archived-page-handler.js
+++ b/src/util/archived-page-handler.js
@@ -1,0 +1,11 @@
+function isInternetArchivedPage(url) {
+  var internetArchiveUrlRegex = new RegExp("/?web/[0-9]+/http://collections.artsmia.org(.*)")
+  var isInternetArchivedPage = url && url.match(internetArchiveUrlRegex)
+  var pageUrl = isInternetArchivedPage && isInternetArchivedPage[1]
+
+  return pageUrl
+}
+
+module.exports = {
+  isInternetArchivedPage
+}


### PR DESCRIPTION
<details>
<summary>UX that allows for saving a detail from the zoomable image of an artwork</summary>
<img width="1235" alt="draggingScreenshot" src="https://user-images.githubusercontent.com/1378/90922783-11d98600-e3dc-11ea-9658-db99919cab89.png">
</details>

This has been a common request, and usually it's achieved by downloading the image, editing it, and re-uploading it somewhere. That's cumbersome and results in the derivative image being disconnected from it's source, so when the time comes to revisit content, there might not even be a clue what the image was originally.

The ideal use of this feature is to pull our the desired region with an IIIF URL for the detail region (such as https://iiif.dx.artsmia.org/4324.jpg/6421,4553,936,814/800,/0/default.jpg) and include that in an external project. Alternately, right click and "Save Image As" to download it and include it in a document or presentation. [It would be great if I could configure the IIIF server to include crucial metadata within the image, or maybe build a 'download' button that modifies the filename to tie back to the original image source?)