### PR TITLE
[MS25-68] Avoid React rendering bug by avoiding nested anchor elements

### DIFF
--- a/src/_artwork.js
+++ b/src/_artwork.js
@@ -46,8 +46,12 @@ var Title = React.createClass({
       (segment) => `<strong>${segment}</strong>`
     );
 
-    var title = <Markdown tag="span">{segmentedTitle}</Markdown>;
     var title = (
+      <Markdown tag="span" allowAnchors={false}>
+        {segmentedTitle}
+      </Markdown>
+    );
+    title = (
       <h1 itemProp="name">
         {title}, <span className="dated">{art.dated}</span>
       </h1>
@@ -485,6 +489,7 @@ var Figure = React.createClass({
         <ConditionalLinkWrapper art={art} link={link}>
           <ArtworkImage
             art={art}
+            allowAnchors={false}
             id={id}
             lazyLoad={false}
             className="artwork-image"

--- a/src/artwork-image.js
+++ b/src/artwork-image.js
@@ -41,14 +41,16 @@ var ArtworkImage = React.createClass({
       showImage && (
         <div className="artwork-image" style={containerStyle}>
           {image}
-          <Markdown>{art.image_copyright}</Markdown>
+          <Markdown allowAnchors={this.props.allowAnchors}>
+            {art.image_copyright}
+          </Markdown>
         </div>
       )
     );
   },
 
   getDefaultProps() {
-    return { lazyLoad: true };
+    return { allowAnchors: true, lazyLoad: true };
   },
 });
 

--- a/src/curators.js
+++ b/src/curators.js
@@ -54,7 +54,9 @@ var Curators = React.createClass({
                     <div className="curator-intro">
                       <h4>{curator.name}</h4>
                       <h5>
-                        <Markdown>{curator.title}</Markdown>
+                        <Markdown allowAnchors={false}>
+                          {curator.title}
+                        </Markdown>
                       </h5>
                     </div>
                   </Link>

--- a/src/decorate/department.js
+++ b/src/decorate/department.js
@@ -110,7 +110,7 @@ var DepartmentDecorator = React.createClass({
                   <div className="curator-intro">
                     <h4>{curator.name}</h4>
                     <h5>
-                      <Markdown>{curator.title}</Markdown>
+                      <Markdown allowAnchors={false}>{curator.title}</Markdown>
                     </h5>
                   </div>
                 </Link>

--- a/src/markdown.js
+++ b/src/markdown.js
@@ -17,7 +17,18 @@ var Markdown = React.createClass({
     let Tag = this.props.tag || "div";
     let rendered = this.props.alreadyRendered ? content : marked(content);
     if (this.props.tag) rendered = rendered.replace(/<.?p>/g, "").trim();
-    return <Tag dangerouslySetInnerHTML={{ __html: rendered }}></Tag>;
+
+    if (!this.props.allowAnchors) {
+      // This component disallows anchors (probably because this element already
+      // appears inside an anchor).
+      rendered = rendered.replace(/<a [^>]+>/g, "").replace(/<\/a>/g, "");
+    }
+
+    return <Tag dangerouslySetInnerHTML={{ __html: rendered }} />;
+  },
+
+  getDefaultProps() {
+    return { allowAnchors: true };
   },
 });
 

--- a/src/peek.js
+++ b/src/peek.js
@@ -73,7 +73,9 @@ var Peek = React.createClass({
           };
     var text =
       this.props.highlightedValue !== this.props.controlValue ? (
-        <Markdown tag="span">{this.props.highlightedValue}</Markdown>
+        <Markdown tag="span" allowAnchors={false}>
+          {this.props.highlightedValue}
+        </Markdown>
       ) : (
         this.props.children
       );

--- a/src/recent.js
+++ b/src/recent.js
@@ -115,6 +115,7 @@ var RecentAccessions = React.createClass({
                           <div className="highlight_image">
                             <div className="highlight_content">
                               <ArtworkImage
+                                allowAnchors={false}
                                 art={highlight}
                                 ignoreStyle={false}
                                 style={{ maxWidth: "111%", maxHeight: "111%" }}


### PR DESCRIPTION
Nested anchor elements are "fixed" by browsers, and this reorganization confuses React's DOM renderer, breaking display. Hence, we try to pass a prop into Markdown uses that are likely to display inside an anchor, and Markdown strips A tags.

Background: URL route `/search/*/filters/room:"G371"` returns artwork 1244 as the first element and this includes an `image_copyright` property with a URL. Because the property is rendered inside an anchor, this resulted in Markdown creating a nested anchor.

Fixed URL: https://collections-app-git-ms25-68-render-bug-artsmia.vercel.app/search/*/filters/room:%22G371%22